### PR TITLE
[ci skip] adding user @simha104

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Cmancuso @ParthivNaresh @bchen1116 @dvreed77 @gsheni @jeff-hernandez @petejanuszewski1 @rwedge @tamargrey @thehomebrewnerd
+* @simha104 @Cmancuso @ParthivNaresh @bchen1116 @dvreed77 @gsheni @jeff-hernandez @petejanuszewski1 @rwedge @tamargrey @thehomebrewnerd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - simha104
     - petejanuszewski1
     - gsheni
     - thehomebrewnerd


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @simha104 as instructed in #51.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #51